### PR TITLE
Ajout d'un filtre et préfixes numéro étudiant

### DIFF
--- a/codes/examens/inscrits_groupe_ldap.php
+++ b/codes/examens/inscrits_groupe_ldap.php
@@ -10,7 +10,7 @@ $chemin = '../..';
 $chemin_commun = $chemin."/commun";
 $chemin_images = $chemin."/images";
 
-require_once($chemin_commun."/c2i_params.php");                 //fichier de paramètres
+require_once($chemin_commun."/c2i_params.php");                 //fichier de paramï¿½tres
 
 require_login("P"); //PP
 
@@ -19,18 +19,18 @@ require_once( $chemin."/templates/class.TemplatePower.inc.php");    //inclusion 
 require_once($chemin_commun."/lib_ldap.php");
 
 
-$idq=required_param("idq",PARAM_INT);   // -1 en création
-$ide=optional_param("ide",$USER->id_etab_perso,PARAM_INT); //étab de l'examen, défaut = ici '
+$idq=required_param("idq",PARAM_INT);   // -1 en crï¿½ation
+$ide=optional_param("ide",$USER->id_etab_perso,PARAM_INT); //ï¿½tab de l'examen, dï¿½faut = ici '
 $retour_fiche=optional_param("retour_fiche","0",PARAM_INT);
 
 $liste=optional_param("liste","",PARAM_RAW);
 $groupes=optional_param("groupes","",PARAM_RAW);
 $format_fic=optional_param("format_fic","",PARAM_ALPHANUM);
 
-//important après avoir lu $ide !!!
+//important aprï¿½s avoir lu $ide !!!
 v_d_o_d("em");
 
-$tpl = new C2IPopup(  ); //créer une instance
+$tpl = new C2IPopup(  ); //crï¿½er une instance
 //inclure d'autre block de templates
 
 $forme=<<<EOL
@@ -108,7 +108,7 @@ if ($liste || $groupes || isset($_FILES["fichier_upl"] )) {
     if (isset($_FILES["fichier_upl"]) && !empty ($_FILES["fichier_upl"]["name"]))  {  //important le 2eme test ///
         //garder ce fichier soit dans csv soit dans apogee
         $dir=$CFG->chemin_ressources."/csv";
-        //récupere le en verifiant taille et type mime ...
+        //rï¿½cupere le en verifiant taille et type mime ...
         $fichier_garde=upload_file('fichier_upl',$dir, $CFG->max_taille_fichiers_uploades,array());
         //, array('text/plain')); pb avec les mac qui n'envoient pas ce type mime
 
@@ -139,7 +139,7 @@ print_select_from_table($tpl,"select_format_fic",$table,"format_fic",false,false
 // rev 1022 afficher les groupes ldap possibles
 if (!empty($CFG->chercher_groupes_ldap)) {
 	$tpl->newBlock ('gldap2');
-	$groups=auth_ldap_get_grouplist();
+	$groups=auth_ldap_get_grouplist($CFG->filtre_groupes_ldap);
 	sort($groups);
 	$table=array();
 	foreach($groups as $group) {

--- a/commun/lib_ldap.php
+++ b/commun/lib_ldap.php
@@ -28,7 +28,11 @@
 
   }
 
+function ldap_maj_config() {
 
+   add_config('ldap','filtre_groupes_ldap', '*', '*', 'Filtre personnalisable de la liste des groupes',1);
+   add_config('ldap', 'numetudiant_prefixes_ldap', '', '', "Liste des préfixes dans le numéro d'étudiant (séparé par des virgules)", 1);
+}
 
 /**
  * conversion ligne csv selon format en une liste de login
@@ -881,6 +885,10 @@ function auth_get_userinfo($username,$getMulti=false){
                 }
             }
             if (!is_null($ldapval)) {
+            	if ($key=='numetudiant'){
+			$prefixe=explode(",",$CFG->numetudiant_prefixes_ldap);
+            		$ldapval=str_replace($prefixe,"",$ldapval);
+            	}
                 $result[$key] = $ldapval;
             }
         }

--- a/installation/database.sql
+++ b/installation/database.sql
@@ -280,6 +280,9 @@ INSERT INTO `c2iconfig` (`id`, `categorie`, `cle`, `valeur`, `defaut`, `descript
 INSERT INTO `c2iconfig` (`id`, `categorie`, `cle`, `valeur`, `defaut`, `description`, `modifiable`, `validation`, `drapeau`) VALUES
 (213, 'pfc2i', 'url_ressources_nationales', 'http://c2i.education.fr/ressources/', 'http://c2i.education.fr/ressources/', 'URL de base des ressources nationales', 1, 'required', 1);
 
+INSERT INTO `c2iconfig` (`id`, `categorie`, `cle`, `valeur`, `defaut`, `description`, `modifiable`, `validation`, `drapeau`) VALUES
+(214, 'ldap', 'filtre_groupes_ldap', '*', '*', 'Filtre personnalisable de la liste des groupes', 1, 'required', 1),
+(215, 'ldap', 'numetudiant_prefixes_ldap', '', '', 'Liste des préfixes dans le numéro d''étudiant (séparé par des virgules)', 1, 'required', 1);
 -- --------------------------------------------------------
 
 --


### PR DESCRIPTION
Ajout de 2 paramètres LDAP:
- Le filtre de la liste des groupes (Nous avons une liste vraiment très longues)
- Les préfixes dans les numéros d'étudiants (dans notre annuaire les numéros d'étudiants sont préfixés `apo-`)

Je pense que c'est de options peuvent aider d'autres universités
